### PR TITLE
Use shuffleboard stylesheets, show correct version to uninstall on 10+

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -34,6 +34,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.layout.Pane;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 @SuppressWarnings("PMD.MoreThanOneLogger") // there's only one logger used, the others are for setting up file logging
 public class Shuffleboard extends Application {
@@ -77,13 +78,19 @@ public class Shuffleboard extends Application {
     // Before we load components that only work with Java 8, check to make sure
     // the application is running on Java 8. If we are running on an invalid
     // version, show an alert and exit before we get into trouble.
-    if (!"1.8".equals(System.getProperty("java.specification.version"))) {
+    String javaSpec = System.getProperty("java.specification.version");
+    String javaVersion = System.getProperty("java.version");
+    if (!"1.8".equals(javaSpec)) {
+      System.out.println(javaSpec);
       Alert invalidVersionAlert = new Alert(Alert.AlertType.ERROR);
       invalidVersionAlert.setHeaderText("Invalid JRE Version!");
       invalidVersionAlert.setContentText(
-          String.format("You are using an unsupported Java version: %s!  "
-                  + "Please download Java 8 and uninstall Java 9.",
-              System.getProperty("java.version")));
+          String.format("You are using an unsupported Java version: %s\n"
+                  + "Please download Java 8 and uninstall Java %s.",
+              javaVersion, javaSpec));
+      invalidVersionAlert.initStyle(StageStyle.UNDECORATED);
+      invalidVersionAlert.getDialogPane().getStylesheets().setAll(
+          AppPreferences.getInstance().getTheme().getStyleSheets());
       invalidVersionAlert.showAndWait();
 
       return;


### PR DESCRIPTION
Since Java 10 will be released in March, and 11 in September, it's infeasible to hardcode "uninstall Java 9"